### PR TITLE
fix: wrap Header component in a <header> element for semantic correct…

### DIFF
--- a/src/pages/_layout.tsx
+++ b/src/pages/_layout.tsx
@@ -13,7 +13,9 @@ const Layout: React.FC = () => {
   return (
     <div className="flex flex-col items-center">
       <div className="sm:max-w-4xl px-6 w-full bg-white">
-        <Header></Header>
+        <header>
+          <Header></Header>
+        </header>
         <div className="mt-4 lg:mt-16"></div>
         <div className="mt-4 lg:mt-16 sh-content">
           <Outlet />


### PR DESCRIPTION
…ness